### PR TITLE
TxtSort fix

### DIFF
--- a/1_TxtSort/CMakeLists.txt
+++ b/1_TxtSort/CMakeLists.txt
@@ -15,7 +15,7 @@ if (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
   find_package(Doxygen)
   if (DOXYGEN_FOUND)
       # set input and output files
-      set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
+      set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/Docs/Doxyfile.in)
       set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
 
       # request to configure the file

--- a/1_TxtSort/TSL/tsl.cc
+++ b/1_TxtSort/TSL/tsl.cc
@@ -280,10 +280,10 @@ int tsl_cb_back_cmp(const void *lhs, const void *rhs)
     while ((rsym != rend) && (!isalpha(*rsym)))
       --rsym;
 
-    if ((lsym > lend) || (rsym > rend))
+    if ((lsym == lend) || (rsym == rend))
       break;
 
-    if (*lsym != *rsym)
+    if (tolower(*lsym) != tolower(*rsym))
       break;
   }
 

--- a/1_TxtSort/TSL/tsl.cc
+++ b/1_TxtSort/TSL/tsl.cc
@@ -257,7 +257,7 @@ int tsl_cb_cmp(const void *lhs, const void *rhs)
     if ((lsym == lend) || (rsym == rend))
       break;
 
-    if (*lsym != *rsym)
+    if (tolower(*lsym) != tolower(*rsym))
       break;
   }
 


### PR DESCRIPTION
Fixed sanitizer's warnings
- [TxtSort-fix] Fix path to Doxygen.in
- [TxtSort-fix] Fixed break condition in back cmp cycle
- [TxtSort-fix] Fixed exit cond in cmp
